### PR TITLE
Updating Aggregator to optionally use transient local qos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.project
 *.cproject
 *.pydevproject
+.vscode/
 *~ 
 

--- a/diagnostic_aggregator/example/README.md
+++ b/diagnostic_aggregator/example/README.md
@@ -3,3 +3,6 @@
 This is a simple example to show the diagnostic_aggregator in action. It involves one python script producing dummy diagnostic data ([example_pub.py](./example_pub.py)), and one diagnostic aggregator configuration ([example.yaml](./example.yaml)) that provides analyzers aggregating it.
 
 Run the example with `ros2 launch diagnostic_aggregator example.launch.py`
+
+## Stateful
+To run the aggregator with stateful publishers and transient_local qos, run the example with `ros2 launch diagnostic_aggregator example.launch.py publish_statefully:=True`

--- a/diagnostic_aggregator/example/example.launch.py.in
+++ b/diagnostic_aggregator/example/example.launch.py.in
@@ -6,29 +6,15 @@ import launch_ros.actions
 analyzer_params_filepath = "@ANALYZER_PARAMS_FILEPATH@"
 
 def generate_launch_description():
-    use_transient_local = launch.substitutions.LaunchConfiguration('use_transient_local')
-    argument = launch.actions.DeclareLaunchArgument(
-        'use_transient_local',
-        default_value='False'
-    )
     aggregator = launch_ros.actions.Node(
         package='diagnostic_aggregator',
         executable='aggregator_node',
         output='screen',
-        parameters=[
-            analyzer_params_filepath,
-            {'subscribe_transient_local': use_transient_local}
-        ],
-    )
+        parameters=[analyzer_params_filepath])
     diag_publisher = launch_ros.actions.Node(
         package='diagnostic_aggregator',
-        parameters=[
-            {'publish_transient_local': use_transient_local}
-        ],
-        executable='example_pub.py'
-    )
+        executable='example_pub.py')
     return launch.LaunchDescription([
-        argument,
         aggregator,
         diag_publisher,
         launch.actions.RegisterEventHandler(

--- a/diagnostic_aggregator/example/example.launch.py.in
+++ b/diagnostic_aggregator/example/example.launch.py.in
@@ -6,15 +6,29 @@ import launch_ros.actions
 analyzer_params_filepath = "@ANALYZER_PARAMS_FILEPATH@"
 
 def generate_launch_description():
+    use_transient_local = launch.substitutions.LaunchConfiguration('use_transient_local')
+    argument = launch.actions.DeclareLaunchArgument(
+        'use_transient_local',
+        default_value='False'
+    )
     aggregator = launch_ros.actions.Node(
         package='diagnostic_aggregator',
         executable='aggregator_node',
         output='screen',
-        parameters=[analyzer_params_filepath])
+        parameters=[
+            analyzer_params_filepath,
+            {'subscribe_transient_local': use_transient_local}
+        ],
+    )
     diag_publisher = launch_ros.actions.Node(
         package='diagnostic_aggregator',
-        executable='example_pub.py')
+        parameters=[
+            {'publish_transient_local': use_transient_local}
+        ],
+        executable='example_pub.py'
+    )
     return launch.LaunchDescription([
+        argument,
         aggregator,
         diag_publisher,
         launch.actions.RegisterEventHandler(

--- a/diagnostic_aggregator/example/example.launch.py.in
+++ b/diagnostic_aggregator/example/example.launch.py.in
@@ -6,6 +6,12 @@ import launch_ros.actions
 analyzer_params_filepath = "@ANALYZER_PARAMS_FILEPATH@"
 
 def generate_launch_description():
+    publish_statefully = launch.substitutions.LaunchConfiguration('publish_statefully')
+    declare_publish_statefully = launch.actions.DeclareLaunchArgument(
+        'publish_statefully',
+        default_value='False',
+        description='set to True to set the example publisher to publish to the stateful topic, with stateful qos',
+    )
     aggregator = launch_ros.actions.Node(
         package='diagnostic_aggregator',
         executable='aggregator_node',
@@ -13,8 +19,12 @@ def generate_launch_description():
         parameters=[analyzer_params_filepath])
     diag_publisher = launch_ros.actions.Node(
         package='diagnostic_aggregator',
+        parameters=[
+            {'publish_statefully': publish_statefully}
+        ],
         executable='example_pub.py')
     return launch.LaunchDescription([
+        declare_publish_statefully,
         aggregator,
         diag_publisher,
         launch.actions.RegisterEventHandler(

--- a/diagnostic_aggregator/example/example_pub.py
+++ b/diagnostic_aggregator/example/example_pub.py
@@ -44,7 +44,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 import rclpy
 from rclpy.clock import ROSClock
 from rclpy.node import Node
-from rclpy.qos import qos_profile_system_default, QoSDurabilityPolicy
+from rclpy.qos import qos_profile_system_default
 
 PKG = 'diagnostic_aggregator'
 
@@ -53,15 +53,10 @@ class DiagnosticTalker(Node):
 
     def __init__(self):
         super().__init__('diagnostic_talker')
-        self.declare_parameter('publish_transient_local', False)
-        use_transient_local = self.get_parameter('publish_transient_local').get_parameter_value().bool_value
-        qos = qos_profile_system_default
-        if use_transient_local:
-            qos.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
         self.i = 0
         self.pub = self.create_publisher(DiagnosticArray,
                                          '/diagnostics',
-                                         qos)
+                                         qos_profile_system_default)
         timer_period = 1.0
         self.tmr = self.create_timer(timer_period, self.timer_callback)
 

--- a/diagnostic_aggregator/example/example_pub.py
+++ b/diagnostic_aggregator/example/example_pub.py
@@ -44,7 +44,7 @@ from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 import rclpy
 from rclpy.clock import ROSClock
 from rclpy.node import Node
-from rclpy.qos import qos_profile_system_default
+from rclpy.qos import qos_profile_system_default, QoSDurabilityPolicy
 
 PKG = 'diagnostic_aggregator'
 
@@ -53,10 +53,15 @@ class DiagnosticTalker(Node):
 
     def __init__(self):
         super().__init__('diagnostic_talker')
+        self.declare_parameter('publish_transient_local', False)
+        use_transient_local = self.get_parameter('publish_transient_local').get_parameter_value().bool_value
+        qos = qos_profile_system_default
+        if use_transient_local:
+            qos.durability = QoSDurabilityPolicy.TRANSIENT_LOCAL
         self.i = 0
         self.pub = self.create_publisher(DiagnosticArray,
                                          '/diagnostics',
-                                         qos_profile_system_default)
+                                         qos)
         timer_period = 1.0
         self.tmr = self.create_timer(timer_period, self.timer_callback)
 

--- a/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
+++ b/diagnostic_aggregator/include/diagnostic_aggregator/aggregator.hpp
@@ -132,7 +132,8 @@ private:
   /// AddDiagnostics, /diagnostics_agg/add_diagnostics
   rclcpp::Service<diagnostic_msgs::srv::AddDiagnostics>::SharedPtr add_srv_;
   /// DiagnosticArray, /diagnostics
-  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_sub_;
+  /// DiagnosticArray, /diagnostics_stateful
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_sub_, diag_stateful_sub_;
   /// DiagnosticArray, /diagnostics_agg
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr agg_pub_;
   /// DiagnosticStatus, /diagnostics_toplevel_state

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -103,6 +103,9 @@ Aggregator::Aggregator()
   diag_sub_ = n_->create_subscription<DiagnosticArray>(
     "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_),
     std::bind(&Aggregator::diagCallback, this, _1));
+  diag_sub_ = n_->create_subscription<DiagnosticArray>(
+    "/diagnostics_stateful", rclcpp::SystemDefaultsQoS().transient_local().keep_last(history_depth_),
+    std::bind(&Aggregator::diagCallback, this, _1));
   agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ =
     n_->create_publisher<DiagnosticStatus>("/diagnostics_toplevel_state", 1);

--- a/diagnostic_aggregator/src/aggregator.cpp
+++ b/diagnostic_aggregator/src/aggregator.cpp
@@ -68,7 +68,6 @@ Aggregator::Aggregator()
 {
   RCLCPP_DEBUG(logger_, "constructor");
   bool other_as_errors = false;
-  bool use_transient_local_qos = false;
 
   std::map<std::string, rclcpp::Parameter> parameters;
   if (!n_->get_parameters("", parameters)) {
@@ -85,17 +84,13 @@ Aggregator::Aggregator()
       other_as_errors = param.second.as_bool();
     } else if (param.first.compare("history_depth") == 0) {
       history_depth_ = param.second.as_int();
-    } else if (param.first.compare("subscribe_transient_local") == 0) {
-      use_transient_local_qos = param.second.as_bool();
     }
   }
-
   RCLCPP_DEBUG(logger_, "Aggregator publication rate configured to: %f", pub_rate_);
   RCLCPP_DEBUG(logger_, "Aggregator base path configured to: %s", base_path_.c_str());
   RCLCPP_DEBUG(
     logger_, "Aggregator other_as_errors configured to: %s", (other_as_errors ? "true" : "false"));
-  RCLCPP_DEBUG(
-    logger_, "Aggregator use_transient_local_qos configured to: %s", (use_transient_local_qos ? "true" : "false"));
+
   analyzer_group_ = std::make_unique<AnalyzerGroup>();
   if (!analyzer_group_->init(base_path_, "", n_)) {
     RCLCPP_ERROR(logger_, "Analyzer group for diagnostic aggregator failed to initialize!");
@@ -105,13 +100,8 @@ Aggregator::Aggregator()
   other_analyzer_ = std::make_unique<OtherAnalyzer>(other_as_errors);
   other_analyzer_->init(base_path_);  // This always returns true
 
-  auto qos = rclcpp::QoS(rclcpp::KeepLast(history_depth_));
-  if (use_transient_local_qos) {
-    qos.transient_local();
-  }
-
   diag_sub_ = n_->create_subscription<DiagnosticArray>(
-    "/diagnostics", qos,
+    "/diagnostics", rclcpp::SystemDefaultsQoS().keep_last(history_depth_),
     std::bind(&Aggregator::diagCallback, this, _1));
   agg_pub_ = n_->create_publisher<DiagnosticArray>("/diagnostics_agg", 1);
   toplevel_state_pub_ =


### PR DESCRIPTION
# summary 
Optionally allow the diagnostics aggregator to subscribe via transient local qos

# test instructions
1. colcon build, source install, etc
2. `ros2 launch diagnostic_aggregator example.launch.py publish_statefully:=True`
3. Use `ros2 topic info /diagnostics_stateful --verbose` to confirm appropriate qos is being used.